### PR TITLE
Add consumes annotation to form endpoints

### DIFF
--- a/src/de/michaelkuerbis/presenter/rest/CronREST.java
+++ b/src/de/michaelkuerbis/presenter/rest/CronREST.java
@@ -4,6 +4,7 @@ import java.text.ParseException;
 import java.util.Vector;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
@@ -11,6 +12,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import net.redhogs.cronparser.CronExpressionDescriptor;
@@ -29,6 +31,7 @@ public class CronREST {
 	private HttpServletRequest webRequest;
 
 	@POST
+	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	@Path("/add/{target}")
 	public Response addChromecast(@PathParam("target") String target,
 			@FormParam("name") String name, @FormParam("url") String url,

--- a/src/de/michaelkuerbis/presenter/rest/StartREST.java
+++ b/src/de/michaelkuerbis/presenter/rest/StartREST.java
@@ -3,10 +3,12 @@ package de.michaelkuerbis.presenter.rest;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import su.litvak.chromecast.api.v2.Application;
@@ -20,6 +22,7 @@ import de.michaelkuerbis.presenter.utils.Settings;
 public class StartREST {
 
 	@POST
+	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	@Path("/{ip}")
 	public Response startCast(@PathParam("ip") String ip,
 			@FormParam("url") String url, @FormParam("reload") int reload) {


### PR DESCRIPTION
I missed something when cleaning up my commits after testing.
I got HTTP 415 errors when starting a cast.

It looks like updating Jersey/jax-rs broke both form endpoints.
Explicitly stating the endpoint expects form data fixes it.

It looks an awful lot like https://github.com/eclipse-ee4j/jersey/issues/3117, but I can't find the real cause.
Adding the annotation can't hurt and it does fix the problem...